### PR TITLE
Ajout d'une section d'informations supplémentaires 

### DIFF
--- a/simulator.html
+++ b/simulator.html
@@ -150,6 +150,32 @@
         </div>
          <div id="calculation-error" style="color: red; margin-top: 15px;"></div>
     </div>
+
+    <div id="additional-info-section" style="margin-top: 40px; padding-top: 20px; border-top: 1px solid #eee; display: none;">
+        <h3>Informations importantes</h3>
+
+        <p style="margin-bottom: 20px;">Ces montants sont donnés à titre indicatif (non contractuels) ; ils peuvent être adaptés en fonction de différents critères (niveau d'intervention d'Indep-RH, volume, conditions de paiement du client, frais de déplacements,...)</p>
+
+        <h4>Informations complémentaires pour les travailleurs frontaliers</h4>
+        <ul style="list-style-type: disc; margin-left: 20px;">
+            <li style="margin-bottom: 10px;">
+                <strong>Assurance maladie :</strong> Les cotisations ne prennent pas en compte l'assurance maladie (ni obligatoire, ni complémentaire). Les travailleurs frontaliers travaillant en Suisse peuvent choisir entre le régime suisse (LAmal) et le régime de sécurité sociale français (CMU).
+            </li>
+            <li style="margin-bottom: 10px;">
+                <strong>LPP :</strong> Un montant significatif (voir tableau ci-dessus sous la rubrique « Epargne LPP ») est retenu, depuis la part patronale, et versé sur un compte de prévoyance professionnelle - ceci est une contrainte légale en Suisse. Ce montant inclut des assurances liées notamment à une invalidité mais aussi (la plus grande partie) à un capital retraite qui est la propriété du travailleur. Ce capital (propriété du salarié) et ses intérêts accumulés sont généralement reversés à l'âge de la retraite sous forme de rente, bien que la loi prévoit la possibilité de versements anticipés en capital sous certaines conditions. En savoir plus sur la <a href="https://www.admin.ch/opc/fr/classified-compilation/19820152/index.html" target="_blank" rel="noopener noreferrer">Loi fédérale sur la prévoyance professionnelle vieillesse, survivants et invalidité (LPP)</a>.
+            </li>
+            <li style="margin-bottom: 10px;">
+                <strong>Impôts :</strong> Le calcul est basé sur les taux d'imposition à la source applicables dans le canton de Genève pour les travailleurs frontaliers ou détenteurs du permis B. Une fois l'impôt à la source payé, si vous n'avez pas d'autres revenus dans votre pays de résidence, vous ne payez aucun autre impôt. Si vous avez d'autres revenus dans votre pays de résidence (des revenus immobiliers par exemple), vous ne payez des impôts que sur ces derniers revenus, mais sur la base d'une assiette d'imposition qui intègre l'ensemble de vos revenus.
+            </li>
+            <li style="margin-bottom: 10px;">
+                 Le statut de salarié vous permet, le cas échéant, d'ouvrir des droits au chômage (suisse si résident suisse ou français si frontalier français) à la fin de la mission.
+            </li>
+            <li style="margin-bottom: 10px;">
+                 Veuillez noter qu'indep-rh se charge de toutes les formalités administratives, en particulier la demande de permis de travail si nécessaire.
+            </li>
+        </ul>
+    </div>
+
 </div>
 
 <script src="config.js"></script> <!-- Load configuration first -->

--- a/simulator.js
+++ b/simulator.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const taxInfoDiv = document.getElementById('tax-info');
     const taxRateInfoSpan = document.getElementById('tax-rate-info');
     const exchangeRateInfoSpan = document.getElementById('exchange-rate-info');
+    const additionalInfoSection = document.getElementById('additional-info-section');
 
     // Lancer la simulation au clic
     calculateButton.addEventListener('click', runSimulation);
@@ -27,6 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // Reset UI
         errorDiv.textContent = '';
         resultsSection.style.display = 'none';
+        additionalInfoSection.style.display = 'none';
 
         const inputs = getInputs();
         if (!inputs) {
@@ -60,6 +62,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 // Affichage des résultats
                 displayResults(finalSBA, finalDeductions, inputs, annualTurnover, annualExpenses);
                 resultsSection.style.display = 'block';
+                additionalInfoSection.style.display = 'block';
                  console.log(`Converged in ${iterations} iterations. Final SBA: ${finalSBA.toFixed(2)}, Final Total Cost: ${(finalSBA + finalDeductions.totalEmployerAnnual + annualExpenses).toFixed(2)}`);
             } else {
                  // Non convergence
@@ -70,6 +73,7 @@ document.addEventListener('DOMContentLoaded', () => {
             console.error("Erreur pendant la simulation:", error);
             errorDiv.textContent = `Erreur lors du calcul : ${error.message}`;
             resultsSection.style.display = 'none';
+            additionalInfoSection.style.display = 'none';
         }
     }
 


### PR DESCRIPTION
Ajout d'une section d'informations supplémentaires concernant les travailleurs frontaliers dans le simulateur, incluant des détails sur l'assurance maladie, la LPP, les impôts et les droits au chômage. Mise à jour du script pour afficher ou masquer cette section en fonction des résultats de la simulation.